### PR TITLE
Add coala question set

### DIFF
--- a/questions/coala.yml
+++ b/questions/coala.yml
@@ -1,0 +1,53 @@
+title: What can I do for coala?
+description: What can I do for coala?
+favicon: https://raw.githubusercontent.com/coala-analyzer/coala-artwork/master/artwork/coala_bear.png
+negatives:
+    - "No"
+    - Nope, nope, nope
+    - Nope
+    - No, thanks
+    - Not on your life
+    - Doesn't sound like me
+    - Absolutely not
+    - Next, please
+affirmatives:
+    - "Yes"
+    - Sounds awesome
+    - Tell me more
+    - That's me!
+    - Totally
+    - Sure
+backlinks:
+    - I was wrong, take me back
+    - I think I made a mistake
+    - Get me outta here!
+
+navlinks:
+    - name: Join
+      link: "javascript:reloadHome();"
+    - name: coala documentation
+      link: http://coala.rtfd.org/
+
+tree:
+  segue1: Want to help coala?
+  segue2: What do you care about?
+  children:
+  - title: Visuals
+    subtitle: The coala artwork team is just for you!
+    href: https://github.com/coala-analyzer/coala-artwork
+  - title: Good Generic Code
+    subtitle: Help us improving code quality in the world! Join the core developers.
+    href: https://github.com/coala-analyzer/coala
+  - title: Reaching Users
+    subtitle: Write documentation that is understandable by everyone.
+    href: http://coala.readthedocs.org/en/latest/Getting_Involved/Writing_Documentation/
+  - title: Make coala Accessible
+    subtitle: Join our translation team!
+    href: http://coala.readthedocs.org/en/latest/Getting_Involved/Translating/
+  - title: Crazy Algorithms
+    subtitle: Let's write code analytics. We write the framework, there's bare logic left for you.
+    href: http://coala.readthedocs.org/en/latest/Users/Writing_Bears/
+  - title: Scientific Progress
+    subtitle: Join our coAST team and create language independent program analysis.
+    href: https://github.com/coala-analyzer/CoAST
+


### PR DESCRIPTION
We're preparing to use asknot-ng for the coala code analysis framework. Our bits of contributions for now:
- A new question set
- You already got a few bug reports
- A theme will follow
