### PR TITLE
Get python3 working again..

### DIFF
--- a/asknot-ng.py
+++ b/asknot-ng.py
@@ -83,9 +83,9 @@ def work(question_filename, template, lang, languages,
     for tree in [statictarget, global_staticdir]:
         if os.path.exists(tree):
             shutil.rmtree(tree)
-    shutil.copytree(staticdir, statictarget)
+    shutil.copytree(staticdir, statictarget, symlinks=True)
 
-    shutil.copytree(global_staticdir_nb, global_staticdir)
+    shutil.copytree(global_staticdir_nb, global_staticdir, symlinks=True)
     print("Copied %s to %s" % (staticdir, statictarget))
 
 


### PR DESCRIPTION
There is a change in the behavior of `shutil.copytree` between python2 and
python3.  In python2 it will copy symlinks by default (even though the
docstring seems to claim it won't) but it is more strictly enforced in the
python3 stdlib implementation.  This patch now explicitly argues
`symlinks=True` which gets things working again on both python2 and python3.
