### PR TITLE
Update Fedora Magazine wiki URL

### DIFF
--- a/questions/includes/fedora/writing.yml
+++ b/questions/includes/fedora/writing.yml
@@ -41,7 +41,7 @@ tree:
         children:
         - title: Fedora Magazine
           subtitle: all Fedora news, all the Fedora time
-          href: http://fedoraproject.org/wiki/FWN/Join
+          href: http://fedoramagazine.org/writing-an-article-for-the-fedora-magazine/
       - title: Less Formal
         subtitle: something more personal
         segue1: We have just the thing for you.


### PR DESCRIPTION
Current wiki URL links to an {{old}} page, this updates the link to the current page that the {{old}} page refers to
