### PR TITLE
questions/gnome: Point to gnome.org not wiki

### DIFF
--- a/questions/gnome.yml
+++ b/questions/gnome.yml
@@ -27,8 +27,8 @@ navlinks:
       link: "javascript:reloadHome();"
     - name: Get GNOME
       link: https://www.gnome.org/getting-gnome/
-    - name: GNOME Wiki
-      link: https://wiki.gnome.org/
+    - name: GNOME.org
+      link: https://www.gnome.org/
 
 tree:
   segue1: Want to help GNOME?


### PR DESCRIPTION
The GNOME wiki is not really the best landing page for newcomers.
gnome.org is _the_ landing page for GNOME and should have a place here
instead.
