### PR TITLE
Alphabetize list, add portingdb

### DIFF
--- a/questions/includes/fedora/coding/python.yml
+++ b/questions/includes/fedora/coding/python.yml
@@ -7,19 +7,23 @@ tree:
     - title: ABRT
       subtitle: the Automatic Bug Reporting Tool
       href: https://github.com/abrt/abrt/wiki/overview
+      
+    - title: DNF
+      subtitle: Dandified Yum (DNF) is a major rewrite of yum
+      href: https://github.com/rpm-software-management/dnf
 
     - title: Firewalld
       subtitle: a dynamically managed firewall with support for network zones
       href: http://www.firewalld.org/contribute/
-
-    - title: Web Services
-      subtitle: Fedora Infrastructure team for the win
-      href: https://fedoraproject.org/wiki/Infrastructure/GettingStarted
-
+      
+    - title: PortingDB
+      subtitle: a <a href"http://portingdb-encukou.rhcloud.com/">dynamic database</a> of Python 2 packages needing to be updated to Python 3
+      href: https://github.com/fedora-python/portingdb/
+      
     - title: Rolekit
       subtitle: a daemon for managing the deployment of <a href="https://fedoraproject.org/wiki/Server/Product_Requirements_Document#Featured_Server_Roles">Server Roles</a>
       href: http://fedorahosted.org/rolekit/
 
-    - title: DNF
-      subtitle: Dandified Yum (DNF) is a major rewrite of yum
-      href: https://github.com/rpm-software-management/dnf
+    - title: Web Services
+      subtitle: Fedora Infrastructure team for the win
+      href: https://fedoraproject.org/wiki/Infrastructure/GettingStarted


### PR DESCRIPTION
This commit does two things:
1) Alphabetize list of Python projects
2) Adds the portingdb as a place to contribute for Python-istas
