### PR TITLE
Create community.yml

### DIFF
--- a/questions/fedora.yml
+++ b/questions/fedora.yml
@@ -45,6 +45,13 @@ tree:
     segue1: "Zeroes and ones #allday?  Me too."
     segue2: What's your favorite language?
     children: includes/fedora/coding.yml
+    
+  - title: Community
+    subtitle: connecting the dots of Fedora
+    image: https://badges.fedoraproject.org/pngs/the-write-stuff.png
+    segue1: Have a knack for community-building?
+    segue2: Perhaps you can lend a hand to...
+    children: includes/fedora/community.yml
 
   - title: Writing
     subtitle: wordsmithery

--- a/questions/fedora.yml
+++ b/questions/fedora.yml
@@ -46,7 +46,7 @@ tree:
     segue2: What's your favorite language?
     children: includes/fedora/coding.yml
     
-  - title: Community
+  - title: Community Operations
     subtitle: connecting the dots of Fedora
     image: https://badges.fedoraproject.org/pngs/the-write-stuff.png
     segue1: Have a knack for community-building?

--- a/questions/includes/fedora/community.yml
+++ b/questions/includes/fedora/community.yml
@@ -1,0 +1,31 @@
+tree:
+  children:
+    - title: Community Operations
+      subtitle: community people passionate about building infrastructure to improve communication
+      image: https://badges.fedoraproject.org/pngs/the-write-stuff.png
+      segue1: Ok.
+      segue2: Would you like something more
+      
+      children:
+        - title: General
+          subtitle: on how to join the Community Operations team?
+          image: https://badges.fedoraproject.org/pngs/fpl-blessing.png
+          href: https://fedoraproject.org/wiki/CommOps
+
+        - title: Specific
+          subtitle: on different kinds of community tasks
+          image: https://badges.fedoraproject.org/pngs/the_panda_is_in.png
+          segue1: Excellent!
+          segue2: How does this sound?
+
+          children:
+          - title: Ambassador
+            subtitle: the representatives of Fedora
+            href: https://fedoraproject.org/wiki/Ambassadors#Who_are_we.3F
+            image: https://badges.fedoraproject.org/pngs/fas-ambassador.png
+          - title: Community Blog
+            subtitle: the central hub of all Fedora news, across the subprojects
+            href: https://communityblog.fedoraproject.org/writing-community-blog-article/
+          - title: 5 Things in Fedora This Week
+            subtitle: finding information for a weekly article about the happenings in Fedora
+            href: https://fedoraproject.org/wiki/CommOps#CommOps_Toolbox


### PR DESCRIPTION
This file aims to provide a new area of contribution for a specific type of community collaborator. Until recently, there was not an area where contributors of this type could easily help with the Project, but the CommOps subgroup aims to help target this kind of collaborator, and more help is needed with these efforts. This is a beginning list of areas that contributors could check out to become involved.

There's not any new badges for the CommOps team yet, but this is subject to change, so I recycled badges from other areas for images.
