### PR TITLE
Sync page when hash changes

### DIFF
--- a/static/js/site.js
+++ b/static/js/site.js
@@ -3,17 +3,20 @@ String.prototype.endsWith = function(suffix) {
     return this.indexOf(suffix, this.length - suffix.length) !== -1;
 };
 
-$(document).ready(function() {
-    // First thing.. hide the warning about javascript being required.
-    $("#js-warning").addClass('hidden');
-
-    var first = question_tree.children[0].id;
-
+function hashSelect(first) {
+    console.log("Changing to new hash...");
     var found = false;
     $.each(all_ids, function(i, idx) {
+        var curr = $('#' + idx);
         if (location.href.endsWith(SEP + idx)) {
-            $("#" + idx).removeClass('hidden');
+            curr.removeClass('hidden');
             found = true;
+        }
+        else {
+            var isHidden = curr.hasClass('hidden');
+            if (! isHidden) {
+                curr.addClass('hidden');
+            }
         }
     });
     if (! found) {
@@ -21,6 +24,14 @@ $(document).ready(function() {
         var original = location.href.replace(/\/$/, "");
         history.pushState({}, '', original + SEP + first);
     }
+}
+
+$(document).ready(function() {
+    // First thing.. hide the warning about javascript being required.
+    $("#js-warning").addClass('hidden');
+
+    var first = question_tree.children[0].id;
+    hashSelect(first);
 
     // Wire up the "yes" links
     $("a.yes").click(function(event) {
@@ -48,6 +59,10 @@ $(document).ready(function() {
         var next = tokens.slice(-1).pop();
         history.go(-1);
         $('#' + next).removeClass('hidden');
+    });
+    $(window).on('hashchange', function() {
+        // Detect hash changes for "back" functions
+        hashSelect(first);
     });
 
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -96,26 +96,25 @@
                 <div class="img"><img src="${node['image']}"/></div>
                 % endif
               </div>
-
-
-                % if 'children' in node:
-                  <p class="lead">
+              % if 'children' in node:
+                <p class="lead">
                   <a data-next="${node['children'][0]['id']}" class="yes btn btn-lg btn-success"><span class="glyphicon glyphicon-ok-sign"></span> ${node['affirmative']}</a>
 
-                % else:
+              % else:
                   <a href="${node['href']}" target="_blank" class="btn btn-lg btn-success"><span class="glyphicon glyphicon-ok-sign"></span> ${node['affirmative']}</a>
-                  </p>
-                % endif:
-                % if next != node['id']:
-                  <p class="lead">
+                </p>
+              % endif:
+
+              % if next != node['id']:
+                <p class="lead">
                   <a data-next="${next}" class="nope btn btn-lg btn-danger"><span class="glyphicon glyphicon-remove-sign"></span> ${node['negative']}</a>
-                  </p>
-                % endif
-              % if not toplevel:
+                </p>
+              % endif
+            % if not toplevel:
               <p class="lead">
                 <a class="back btn btn-lg btn-warning"><span class="glyphicon glyphicon-circle-arrow-left"></span> ${node['backlink']}</a>
               </p>
-              % endif
+            % endif
             </div>
 
             % if 'children' in node:


### PR DESCRIPTION
This patch ensures the page updates accordingly when the hash values change. Before this fix, changes in the hash were not reflected on the page. This renders the HTML5 history modifications and other future changes dependent on the page self-updating ineffective.
- Sync page whenever hash changes (e.g `#coding` to `#translation` will update page to translation slide)
- Small bugfix with indentation (HTML seems to be 2-space indentation...JS seems to be 4. I didn't fix this)

I'll make a PR in the future to add functionality as described in #19, but this is a good step forward towards that goal :)
