### PR TITLE
coala: Remove "Translation Team" hook

### DIFF
--- a/questions/coala.yml
+++ b/questions/coala.yml
@@ -43,9 +43,6 @@ tree:
   - title: Reaching Users
     subtitle: Write documentation that is understandable by everyone.
     href: http://coala.readthedocs.org/en/latest/Getting_Involved/Writing_Documentation/
-  - title: Make coala Accessible
-    subtitle: Join our translation team!
-    href: http://coala.readthedocs.org/en/latest/Getting_Involved/Translating/
   - title: Crazy Algorithms
     subtitle: Let's write code analytics. We write the framework, there's bare logic left for you.
     href: http://coala.readthedocs.org/en/latest/Users/Writing_Bears/


### PR DESCRIPTION
We removed i18n for coala.
