### PR TITLE
Update link to PortingDB

### DIFF
--- a/questions/includes/fedora/coding/python.yml
+++ b/questions/includes/fedora/coding/python.yml
@@ -17,8 +17,8 @@ tree:
       href: http://www.firewalld.org/contribute/
       
     - title: PortingDB
-      subtitle: a <a href"http://portingdb-encukou.rhcloud.com/">dynamic database</a> of Python 2 packages needing to be updated to Python 3
-      href: https://github.com/fedora-python/portingdb/
+      subtitle: a <a href="http://fedora.portingdb.xyz/">dynamic database</a> of Python 2 packages needing to be updated to Python 3
+      href: http://fedora.portingdb.xyz/
       
     - title: Rolekit
       subtitle: a daemon for managing the deployment of <a href="https://fedoraproject.org/wiki/Server/Product_Requirements_Document#Featured_Server_Roles">Server Roles</a>


### PR DESCRIPTION
- use portingdb.xyz instead of rhcloud.com
- get people to the PortingDB instead of GitHub repo
- fix HTML error to make the link active
