### PR TITLE
Fix Cloud/RDO "Get involved" link

### DIFF
--- a/questions/includes/fedora/cloud.yml
+++ b/questions/includes/fedora/cloud.yml
@@ -5,4 +5,4 @@ tree:
       href: https://fedoraproject.org/wiki/Cloud_SIG
     - title: RDO
       subtitle: the OpenStack distro for Fedora
-      href: https://rdoproject.org/Get_involved
+      href: https://www.rdoproject.org/documentation/onboarding/


### PR DESCRIPTION
"Get involved" link for RDO was broken. Updated with a new address.