### PR TITLE
Add ability to add per-site Google Webmaster Tools validation code (and add the fedora one specifically)

### DIFF
--- a/asknot_lib.py
+++ b/asknot_lib.py
@@ -42,6 +42,7 @@ defaults = {
     ),
     'asknot_version': asknot_version(),
     'favicon': 'whatever',
+    'googlesiteverification': 'n/a',
     'navlinks': [],
     'negatives': ['No, thanks'],
     'affirmatives': ['Yes, please'],

--- a/questions/fedora.yml
+++ b/questions/fedora.yml
@@ -1,6 +1,7 @@
 title: What can I do for Fedora?
 description: What can I do for Fedora?
 favicon: https://getfedora.org/static/images/favicon.ico
+google-site-verification: a-S_XZt6rQej92LXTbscezXa1RLTN1KoaLoPUyvwAGM
 negatives:
     - "No"
     - Nope, nope, nope

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="${description}">
     <meta name="author" content="${author}">
+    <meta name="google-site-verification" content="${googlesiteverification}" />
     <link rel="shortcut icon" href="${favicon}">
 
     <title>${title}</title>


### PR DESCRIPTION
This will let us do some basic instruction about the site to google, and get some simple metrics back from google. 

It doesn't enable any user tracking or anything (beyond what google, of course, already does)