### PR TITLE
Remove Rolekit

### DIFF
--- a/questions/includes/fedora/coding/python.yml
+++ b/questions/includes/fedora/coding/python.yml
@@ -19,10 +19,6 @@ tree:
     - title: PortingDB
       subtitle: a <a href="http://fedora.portingdb.xyz/">dynamic database</a> of Python 2 packages needing to be updated to Python 3
       href: http://fedora.portingdb.xyz/
-      
-    - title: Rolekit
-      subtitle: a daemon for managing the deployment of <a href="https://fedoraproject.org/wiki/Server/Product_Requirements_Document#Featured_Server_Roles">Server Roles</a>
-      href: http://fedorahosted.org/rolekit/
 
     - title: Web Services
       subtitle: Fedora Infrastructure team for the win


### PR DESCRIPTION
The most recent information on Rolekit I can find was in reference to Fedora 21, and with Cockpit having the functionality in Fedora 23. Since I can no longer find a project page, I find it suitable to remove Rolekit from the project prompts. Additionally, since I was unsure if Cockpit was the proper replacement for Rolekit, I have filed an issue on the topic.