### PR TITLE
Switch back to making the site with python2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 ./compile-translations.sh
 
-python3 asknot-ng.py \
+python asknot-ng.py \
 	./templates/index.html \
 	./questions/fedora.yml \
 	./l10n/fedora/locale \


### PR DESCRIPTION
The site currently builds on sundries01/sundries01.stg and those are
rhel7 instances. There is no python3 mako available, so the build fails
and sends a failure email to all the websites folks.