### PR TITLE
Remove Python 2.6 from Travis yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
 
 # command to install dependencies


### PR DESCRIPTION
Travis can't download Python 2.6 anymore, therefore it should be removed from the Travis yml file.
Otherwise all builds would fail.