### PR TITLE
Replace OSSCDN with jsDelivr

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -24,8 +24,8 @@
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/html5shiv@3.7.3/dist/html5shiv.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/respond.js@1.4.2/dest/respond.min.js"></script>
     <![endif]-->
   </head>
 


### PR DESCRIPTION
https://www.jsdelivr.com/osscdn

The old links now return '500 Internal Error'.

Also upgrade html5shiv to 3.7.3 while at it:
https://github.com/aFarkas/html5shiv/compare/3.7.2...3.7.3