### PR TITLE
Switch to nose2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ python:
 cache: pip
 
 # command to install dependencies
-install: pip install nose PyYAML
+install: pip install nose2 PyYAML
 # command to run tests
-script: nosetests
+script: nose2
 
 notifications:
   email: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ mako
 PyYAML
 
 # nose is only required for testing
-nose
+nose2


### PR DESCRIPTION
nose package is no longer maintained and doesn't work with latest
python. This commit is switching the test suite to nose2.
https://github.com/nose-devs/nose2

Signed-off-by: Michal Konečný <mkonecny@redhat.com>