### PR TITLE
Update link to "Joining the Package Maintainers" to docs.fedoraproject.org

### DIFF
--- a/questions/includes/fedora/packaging.yml
+++ b/questions/includes/fedora/packaging.yml
@@ -2,4 +2,4 @@ tree:
   children:
     - title: Package Maintainer
       subtitle: steward of the packages in Fedora
-      link: https://fedoraproject.org/wiki/Join_the_package_collection_maintainers#How_to_join_the_Fedora_Package_Collection_Maintainers.3F
+      link: https://docs.fedoraproject.org/en-US/package-maintainers/Joining_the_Package_Maintainers/


### PR DESCRIPTION
The current link now only directs you to the new link.
![image](https://user-images.githubusercontent.com/18211838/154088217-ee05d917-23fd-4f2a-b5cf-8ecdcac86b41.png)
