### PR TITLE
Update GNOME Link to Newcomers Wiki

### DIFF
--- a/questions/includes/fedora/coding/c.yml
+++ b/questions/includes/fedora/coding/c.yml
@@ -14,7 +14,7 @@ tree:
 
     - title: GNOME
       subtitle: an easy and elegant way to use your computer
-      link: http://www.gnome.org/gnome-3/source/
+      link: https://www.gnome.org/get-involved/
 
     - title: The Linux Kernel
       subtitle: that thing that connects application software to the hardware of a computer

--- a/questions/includes/fedora/coding/c.yml
+++ b/questions/includes/fedora/coding/c.yml
@@ -14,7 +14,7 @@ tree:
 
     - title: GNOME
       subtitle: an easy and elegant way to use your computer
-      link: https://www.gnome.org/get-involved/
+      link: https://wiki.gnome.org/Newcomers/
 
     - title: The Linux Kernel
       subtitle: that thing that connects application software to the hardware of a computer


### PR DESCRIPTION
The link to the GNOME Webpage no longer exists. Redirect new contributors to Get Involved - GNOME Webpage. 
https://www.gnome.org/get-involved/

Error 404 for old webpage:

![image](https://user-images.githubusercontent.com/99819848/155513313-aafcbcad-3bb5-4598-876b-95d6b578aebb.png)
