### PR TITLE
Replace dead links

### DIFF
--- a/questions/includes/fedora/community.yml
+++ b/questions/includes/fedora/community.yml
@@ -3,7 +3,7 @@ tree:
     - title: General
       subtitle: on how to join the Community Operations team?
       image: https://badges.fedoraproject.org/pngs/fpl-blessing.png
-      link: https://docs.fedoraproject.org/en-US/commops/latest/
+      link: https://docs.fedoraproject.org/en-US/commops/
 
     - title: Specific
       subtitle: on different kinds of community tasks
@@ -21,4 +21,4 @@ tree:
           link: https://communityblog.fedoraproject.org/writing-community-blog-article/
         - title: 5 Things in Fedora This Week
           subtitle: finding information for a weekly article about the happenings in Fedora
-          link: https://docs.fedoraproject.org/en-US/commops/latest/contribute/commops-landing/#toolbox
+          link: https://docs.fedoraproject.org/en-US/commops/contribute/commops-landing/#toolbox

--- a/questions/includes/fedora/community.yml
+++ b/questions/includes/fedora/community.yml
@@ -3,7 +3,7 @@ tree:
     - title: General
       subtitle: on how to join the Community Operations team?
       image: https://badges.fedoraproject.org/pngs/fpl-blessing.png
-      link: https://fedoraproject.org/wiki/CommOps
+      link: https://docs.fedoraproject.org/en-US/commops/latest/
 
     - title: Specific
       subtitle: on different kinds of community tasks
@@ -21,4 +21,4 @@ tree:
           link: https://communityblog.fedoraproject.org/writing-community-blog-article/
         - title: 5 Things in Fedora This Week
           subtitle: finding information for a weekly article about the happenings in Fedora
-          link: https://fedoraproject.org/wiki/CommOps#CommOps_Toolbox
+          link: https://docs.fedoraproject.org/en-US/commops/latest/contribute/commops-landing/#toolbox


### PR DESCRIPTION
The CommOps page didn't exist on the fedora wiki, so replaced it with a working fedora docs page for the same.