### PR TITLE
Update link to GNOME source

### DIFF
--- a/questions/includes/fedora/coding/c.yml
+++ b/questions/includes/fedora/coding/c.yml
@@ -14,7 +14,7 @@ tree:
 
     - title: GNOME
       subtitle: an easy and elegant way to use your computer
-      link: http://www.gnome.org/gnome-3/source/
+      link: https://gitlab.gnome.org/
 
     - title: The Linux Kernel
       subtitle: that thing that connects application software to the hardware of a computer


### PR DESCRIPTION
The current link is a 404.
The link to "Source Code" from the footer of the official gnome.org site points to this url, so I propose we use that.