### PR TITLE
Update obsolete systemd link.

### DIFF
--- a/questions/includes/fedora/coding/c.yml
+++ b/questions/includes/fedora/coding/c.yml
@@ -6,7 +6,7 @@ tree:
 
     - title: systemd
       subtitle: widely renowned init system and suite of building blocks
-      link: https://www.freedesktop.org/wiki/Software/systemd/
+      link: https://systemd.io/
 
     - title: Cockpit
       subtitle: a server manager that makes it easy to administer via a web browser


### PR DESCRIPTION
The previous link under coding/c/systemd points to a page marked as obsolete and replaced:

"This page has been obsoleted and replaced. All the new contents are on the new website: https://systemd.io/."

This commit updates the link to https://systemd.io/.